### PR TITLE
added dnoegel/php-xdg-base-dir

### DIFF
--- a/app/Commands/InteractsWithChatGpt.php
+++ b/app/Commands/InteractsWithChatGpt.php
@@ -3,11 +3,14 @@
 namespace App\Commands;
 
 use App\ChatGpt;
+use App\Concerns\BaseDir;
 use Illuminate\Support\Facades\File;
 
 /** @mixin \LaravelZero\Framework\Commands\Command */
 trait InteractsWithChatGpt
 {
+    use BaseDir;
+
     /**
      * The ChatGPT API client.
      */
@@ -66,6 +69,6 @@ trait InteractsWithChatGpt
      */
     protected function getChatGptSessionPath(): string
     {
-        return $_SERVER['HOME'] . DIRECTORY_SEPARATOR . '.gpt_session';
+        return $this->getHomeDir() . DIRECTORY_SEPARATOR . '.gpt_session';
     }
 }

--- a/app/Commands/InteractsWithGitHub.php
+++ b/app/Commands/InteractsWithGitHub.php
@@ -2,12 +2,15 @@
 
 namespace App\Commands;
 
+use App\Concerns\BaseDir;
 use Github\AuthMethod;
 use Github\Client;
 use Illuminate\Support\Facades\File;
 
 trait InteractsWithGitHub
 {
+    use BaseDir;
+
     /**
      * The GitHub API client.
      */
@@ -55,6 +58,6 @@ trait InteractsWithGitHub
      */
     protected function getGitHubAccessTokenPath(): string
     {
-        return $_SERVER['HOME'] . DIRECTORY_SEPARATOR . '.gh_token';
+        return $this->getHomeDir() . DIRECTORY_SEPARATOR . '.gh_token';
     }
 }

--- a/app/Concerns/BaseDir.php
+++ b/app/Concerns/BaseDir.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Concerns;
+
+trait BaseDir
+{
+    public function getHomeDir(): string
+    {
+        return (new \XdgBaseDir\Xdg())->getHomeDir();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": "^8.1",
+        "dnoegel/php-xdg-base-dir": "^0.1.1",
         "gioni06/gpt3-tokenizer": "^1.1",
         "guzzlehttp/guzzle": "^7.5",
         "illuminate/http": "^10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d55f3c899bd69ea8f1dc8507926326a5",
+    "content-hash": "c9c3cde8dc30c3e4dd456143fd716510",
     "packages": [
         {
             "name": "brick/math",
@@ -127,6 +127,43 @@
                 }
             ],
             "time": "2022-02-21T13:15:14+00:00"
+        },
+        {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
         },
         {
             "name": "doctrine/inflector",


### PR DESCRIPTION
In `windows` instead of `$_SERVER['HOME']` there are `HOMEDIR` & `HOMEPATH` @PHP-8.1.

`dnoegel/php-xdg-base-dir` uses XDG Base Directory specification.